### PR TITLE
adding clarity around install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,12 @@ This starter uses [Astro](https://astro.build/) for the frontend and [Sanity](ht
 
 ## Getting started
 
-The following commands are meant to be run in **both** the `/app` and `/studio` folders.
-
-1. `npm install` to install dependencies
-2. `npm create sanity@latest init --env`, this will:
-
-- ask you to select or create a Sanity project and dataset
-- output a `.env` file with appropriate variables
-- _(or use `sanity init --env` if you have the CLI installed)_
-
-3. `npm run dev` to start the development server
+1. Run `npm install` to install dependencies in **both** the `/app` and `/studio` folders.
+2. Run `npm create sanity@latest init --env` in just the `/studio` folder, this will:
+    - ask you to select or create a Sanity project and dataset
+    - output a `.env` file with appropriate variables
+    - _(or use `sanity init --env` if you have the CLI installed)_
+3. `npm run dev` from **both** the `/app` and `/studio` folders to start the development server
 
 Your Astro app should now be running on [http://localhost:3000/](http://localhost:3000/) and Studio on [http://localhost:3333/](http://localhost:3333/).
 


### PR DESCRIPTION
I am adding a few changes to make the install instructions a little more clear.

Previously, it seemed like you needed to run `npm create sanity@latest init --env` from both the `/app` and `/studio` folders, when it looks like you only need to run that command from the `/studio folder`. 

It was also not clear where to run `npm run dev`, so I indicated that it should also be ran from both folders.

Hope this is helpful.