### PR TITLE
fix: add vercel native env variables as fallback

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,9 +3,16 @@
 import { loadEnv } from "vite";
 const {
   PUBLIC_SANITY_STUDIO_PROJECT_ID,
-  PUBLIC_SANITY_STUDIO_DATASET
+  PUBLIC_SANITY_STUDIO_DATASET,
+  PUBLIC_SANITY_PROJECT_ID,
+  PUBLIC_SANITY_DATASET,
 } = loadEnv(import.meta.env.MODE, process.cwd(), "");
 import { defineConfig } from "astro/config";
+
+// Different environments use different variables
+const projectId = PUBLIC_SANITY_STUDIO_PROJECT_ID || PUBLIC_SANITY_PROJECT_ID;
+const dataset = PUBLIC_SANITY_STUDIO_DATASET || PUBLIC_SANITY_DATASET;
+
 import sanity from "@sanity/astro";
 import react from "@astrojs/react";
 
@@ -19,8 +26,8 @@ export default defineConfig({
   output: "hybrid",
   adapter: vercel(),
   integrations: [sanity({
-    projectId: PUBLIC_SANITY_STUDIO_PROJECT_ID,
-    dataset: PUBLIC_SANITY_STUDIO_DATASET,
+    projectId,
+    dataset,
     studioBasePath: "/admin",
     useCdn: false,
     // `false` if you want to ensure fresh data

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,5 +1,10 @@
-const projectId = import.meta.env.PUBLIC_SANITY_STUDIO_PROJECT_ID!;
-const dataset = import.meta.env.PUBLIC_SANITY_STUDIO_DATASET!;
+// Different environments use different variables
+const projectId =
+  import.meta.env.PUBLIC_SANITY_STUDIO_PROJECT_ID! ||
+  import.meta.env.PUBLIC_SANITY_PROJECT_ID!;
+const dataset =
+  import.meta.env.PUBLIC_SANITY_STUDIO_DATASET! ||
+  import.meta.env.PUBLIC_SANITY_DATASET!;
 
 // Feel free to remove this check if you don't need it
 if (!projectId || !dataset) {


### PR DESCRIPTION
We should probably look into how we can reconcile this more neatly, but for the time being, this is a fix that accomodate both the env variables made by the Sanity CLI and those set when deploying to Vercel. 