### PR TITLE
Add support for `sanity schema extract`.

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,16 +1,15 @@
+const env = process.env ?? import.meta.env;
+
 // Different environments use different variables
 const projectId =
-  import.meta.env.PUBLIC_SANITY_STUDIO_PROJECT_ID! ||
-  import.meta.env.PUBLIC_SANITY_PROJECT_ID!;
-const dataset =
-  import.meta.env.PUBLIC_SANITY_STUDIO_DATASET! ||
-  import.meta.env.PUBLIC_SANITY_DATASET!;
+  env.PUBLIC_SANITY_STUDIO_PROJECT_ID! || env.PUBLIC_SANITY_PROJECT_ID!;
+const dataset = env.PUBLIC_SANITY_STUDIO_DATASET! || env.PUBLIC_SANITY_DATASET!;
 
 // Feel free to remove this check if you don't need it
 if (!projectId || !dataset) {
   throw new Error(
     `Missing environment variable(s). Check if named correctly in .env file.\n\nShould be:\nPUBLIC_SANITY_STUDIO_PROJECT_ID=${projectId}\nPUBLIC_SANITY_STUDIO_DATASET=${dataset}\n\nAvailable environment variables:\n${JSON.stringify(
-      import.meta.env,
+      env,
       null,
       2
     )}`


### PR DESCRIPTION
👋 This adds support for `sanity schema extract`. It does however generate the following warning:
```
⠋ Extracting schema{
  column: 27,
  file: 'sanity.config.ts',
  length: 11,
  line: 1,
  lineText: 'const env = process.env ?? import.meta.env;',
  namespace: '',
  suggestion: ''
}
⠙ Extracting schema"import.meta" is not available with the "cjs" output format and will be empty
```