### PR TITLE
Fix: Update package.json / Remove Engine Declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,5 @@
     "rimraf": "5.0.1",
     "typescript": "^5.5.2",
     "vite": "^5.3.2"
-  },
-  "engines": {
-    "node": ">= 16.12"
   }
 }


### PR DESCRIPTION
Resolves: 
Error: The following Serverless Functions contain an invalid "runtime":
  - _render (nodejs18.x). Learn More: https://vercel.com/guides/serverless-function-contains-invalid-runtime-error

** Vercel's Node Version Must Be Set To 18' in Settings As Well