### PR TITLE
Add Tailwind CSS and Typography plugin

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -19,6 +19,8 @@ import react from "@astrojs/react";
 // https://docs.astro.build/en/guides/server-side-rendering/#adding-an-adapter
 import vercel from "@astrojs/vercel";
 
+import tailwindcss from "@tailwindcss/vite";
+
 // https://astro.build/config
 export default defineConfig({
   // Set to 'server' for Visual Editing and on-demand rendering
@@ -50,5 +52,7 @@ export default defineConfig({
         "lodash/sortedIndex.js",
       ],
     },
+
+    plugins: [tailwindcss()],
   },
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@sanity/astro": "^3.3.1",
     "@sanity/client": "^7.21.0",
     "@sanity/image-url": "^2.1.1",
+    "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "astro": "^6.1.6",
@@ -26,11 +27,13 @@
     "react-dom": "^19.2.5",
     "react-is": "^19.2.5",
     "sanity": "^5.20.0",
-    "styled-components": "^6.4.0"
+    "styled-components": "^6.4.0",
+    "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@portabletext/types": "^4.0.2",
     "@sanity/types": "^5.20.0",
+    "@tailwindcss/typography": "^0.5.19",
     "prettier": "^3.8.2",
     "prettier-plugin-astro": "^0.14.1",
     "typescript": "^5.9.3"

--- a/frontend/src/components/Card.astro
+++ b/frontend/src/components/Card.astro
@@ -25,11 +25,11 @@ const dataAttr = visualEditingEnabled
   : null;
 ---
 
-<div class="card">
+<div class="relative flex flex-col border-b border-gray-200 p-2 first:rounded-t last:rounded-b sm:border sm:border-b-0 sm:last:border-b md:flex-row">
   {
     post.mainImage ? (
       <img
-        class="card__cover"
+        class="h-57.75 w-full object-cover md:min-w-[366.5px] md:max-w-[366.5px] md:max-h-57.75"
         src={urlFor(post.mainImage).width(500).height(300).fit("crop").auto("format").quality(80).url()}
         srcset={buildSrcSet(post.mainImage, [366, 500, 732], 80)}
         sizes="(max-width: 800px) 100vw, 366px"
@@ -41,130 +41,21 @@ const dataAttr = visualEditingEnabled
         data-sanity={dataAttr?.scope("mainImage").toString()}
       />
     ) : (
-      <div class="card__cover--none" />
+      <div class="h-57.75 w-full bg-black md:min-w-[366.5px] md:max-w-[366.5px] md:max-h-57.75" />
     )
   }
-  <div class="card__container">
-    <h3 class="card__title">
+  <div class="mx-1 md:mx-5">
+    <h3 class="font-sans font-extrabold text-4xl leading-9 -tracking-[0.025em] my-3 sm:mt-5">
       <a
-        class="card__link"
+        class="text-black no-underline hover:opacity-80 transition-opacity duration-200 before:content-[''] before:absolute before:inset-0"
         href={`/post/${post.slug.current}`}
       >
         {post.title}
       </a>
     </h3>
-    <p class="card__excerpt">{post.excerpt}</p>
-    <p class="card__date">
+    <p class="font-serif font-normal text-xl leading-7 mt-0">{post.excerpt}</p>
+    <p class="font-sans font-semibold text-sm mt-7">
       {formatDate(post._createdAt)}
     </p>
   </div>
 </div>
-
-<style>
-  .card {
-    display: flex;
-    flex-direction: column;
-    padding: var(--space-2);
-    padding: 9px;
-    position: relative;
-    border-bottom: 1px solid #ced2d9;
-
-    & .card__container {
-      margin: 0 var(--space-1) 0;
-    }
-
-    & .card__cover {
-      width: 100%;
-      height: 231px;
-      object-fit: cover;
-    }
-
-    & .card__cover--none {
-      width: 100%;
-      height: 231px;
-      background: var(--black);
-    }
-
-    & .card__title {
-      font-family: var(--font-family-sans);
-      font-weight: 800;
-      font-size: var(--font-size-7);
-      line-height: var(--line-height-6);
-      letter-spacing: -0.025em;
-      margin: var(--space-3) 0;
-    }
-
-    & .card__excerpt {
-      font-family: var(--font-family-serif);
-      font-weight: 400;
-      font-size: var(--font-size-4);
-      line-height: var(--line-height-3);
-      margin-top: 0;
-    }
-
-    & .card__date {
-      font-weight: 600;
-      font-family: var(--font-family-sans);
-      font-size: var(--font-size-1);
-      margin-top: calc(var(--space-4) + 7px);
-    }
-
-    & .card__link {
-      color: var(--black);
-      text-decoration: none;
-
-      &:hover {
-        opacity: 0.8;
-        transition: 0.2s;
-      }
-
-      &::before {
-        content: "";
-        position: absolute;
-        inset: 0;
-      }
-    }
-
-    &:first-child {
-      border-top-left-radius: 3px;
-      border-top-right-radius: 3px;
-    }
-
-    &:last-child {
-      border-bottom-left-radius: 3px;
-      border-bottom-right-radius: 3px;
-    }
-  }
-
-  @media (min-width: 575px) {
-    .card {
-      border: 1px solid #ced2d9;
-      border-bottom: none;
-
-      & .card__title {
-        margin-top: var(--space-4);
-      }
-
-      &:last-child {
-        border-bottom: 1px solid #ced2d9;
-      }
-    }
-  }
-
-  @media (min-width: 800px) {
-    .card {
-      flex-direction: row;
-
-      & .card__container {
-        margin: 0 var(--space-4) 0;
-      }
-
-      & .card__cover,
-      & .card__cover--none {
-        min-width: 366.5px;
-        max-width: 366.5px;
-        max-height: 231px;
-      }
-    }
-  }
-</style>

--- a/frontend/src/components/Welcome.astro
+++ b/frontend/src/components/Welcome.astro
@@ -2,28 +2,29 @@
 
 ---
 
-<div class="container">
-  <div class="logos">
-    <div class="logos__blur"></div>
-    <img class="logos__entry" src="/astro.svg" alt="Astro Logo" />
-    <span class="logos__plus">+</span>
-    <img class="logos__entry" src="/sanity.svg" alt="Sanity Logo" />
+<div class="flex flex-col items-center px-2">
+  <div class="hidden sm:flex items-center my-13 mb-8">
+    <div class="absolute flex w-93.75 h-28.75 bg-magenta-100 blur-[82px] -rotate-19 -z-1"></div>
+    <img class="flex" src="/astro.svg" alt="Astro Logo" />
+    <span class="flex font-sans font-extrabold text-4xl leading-9 mx-5">+</span>
+    <img class="flex" src="/sanity.svg" alt="Sanity Logo" />
   </div>
-  <div class="steps">
-    <h2 class="steps__title">Next steps</h2>
-    <ul class="steps__list">
-      <li class="steps__entry">
-        <h3 class="steps__subtitle">Publish a post in your Studio</h3>
-        <p class="steps__text">
-          Visit the <a href="http://localhost:3333/">Sanity Studio</a> and publish
+  <div class="flex-col w-full sm:flex sm:max-w-xs sm:p-0">
+    <h2 class="text-2xl leading-6">Next steps</h2>
+    <ul class="list-none p-0 sm:mt-0">
+      <li class="mb-5">
+        <h3 class="text-lg leading-6 sm:mt-5">Publish a post in your Studio</h3>
+        <p class="font-serif leading-6">
+          Visit the <a class="text-blue-600 no-underline" href="http://localhost:3333/">Sanity Studio</a> and publish
           a new document of type post.
         </p>
       </li>
-      <li class="steps__entry">
-        <h3 class="step__title">Dive into the documentation</h3>
-        <p class="steps__text">
+      <li class="mb-5">
+        <h3 class="text-lg leading-6 sm:mt-5">Dive into the documentation</h3>
+        <p class="font-serif leading-6">
           Check out{" "}
           <a
+            class="text-blue-600 no-underline"
             target="_blank"
             rel="noopener noreferrer nofollow"
             href="https://www.sanity.io/docs"
@@ -33,11 +34,12 @@
           to learn more about Sanity.
         </p>
       </li>
-      <li class="steps__entry">
-        <h3 class="steps__subtitle">Join the Sanity Discord</h3>
-        <p class="steps__text">
+      <li class="mb-5">
+        <h3 class="text-lg leading-6 sm:mt-5">Join the Sanity Discord</h3>
+        <p class="font-serif leading-6">
           Leverage{" "}
           <a
+            class="text-blue-600 no-underline"
             target="_blank"
             rel="noopener noreferrer nofollow"
             href="https://snty.link/community"
@@ -50,100 +52,3 @@
     </ul>
   </div>
 </div>
-
-<style>
-  .container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: var(--space-2) var(--space-2);
-  }
-
-  .logos {
-    display: none;
-  }
-
-  .steps {
-    flex-direction: column;
-    width: 100%;
-
-    & .steps__list {
-      list-style-type: none;
-      padding: 0;
-    }
-
-    & .steps__entry {
-      margin-bottom: var(--space-4);
-    }
-
-    & .steps__title {
-      font-size: var(--font-size-5);
-      line-height: var(--line-height-2);
-    }
-
-    & .steps__subtitle {
-      font-size: var(--font-size-3);
-      line-height: var(--line-height-2);
-    }
-
-    & .steps__text {
-      font-family: var(--font-family-serif);
-      line-height: var(--line-height-2);
-
-      & a {
-        color: var(--blue-600);
-        text-decoration: none;
-      }
-    }
-  }
-
-  @media (min-width: 575px) {
-    .container {
-      width: 100%;
-    }
-
-    .logos {
-      display: flex;
-      align-items: center;
-      margin: var(--space-6) 0 var(--space-5) 0;
-
-      & .logos__blur {
-        display: flex;
-        position: absolute;
-        width: 375px;
-        height: 115px;
-        background: var(--magenta-100);
-        filter: blur(82px);
-        transform: rotate(-19deg);
-        z-index: -1;
-      }
-
-      & .logos__plus {
-        display: flex;
-        font-family: var(--font-family-sans);
-        font-weight: 800;
-        font-size: var(--font-size-7);
-        line-height: var(--line-height-6);
-        margin: 0 var(--space-4);
-      }
-
-      & .logos__entry {
-        display: flex;
-      }
-    }
-
-    .steps {
-      max-width: var(--max-width-0);
-      display: flex;
-      padding: 0;
-
-      & .steps__subtitle {
-        margin-top: var(--space-4);
-      }
-
-      & .steps__list {
-        margin-top: 0;
-      }
-    }
-  }
-</style>

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import { VisualEditing } from "@sanity/astro/visual-editing";
+import "../styles/global.css";
 
 interface Props {
   title: string;
@@ -53,15 +54,15 @@ const visualEditingEnabled =
   </head>
   <body>
     <VisualEditing enabled={visualEditingEnabled} />
-    <div class="container">
-      <header class="header">
-        <a class="header__title" href="/">Astro + Sanity</a>
+    <div class="mx-auto sm:max-w-3xl sm:px-5">
+      <header class="fixed left-0 right-0 top-0 z-10 flex border-b border-gray-200 bg-white px-1 sm:static sm:border-b-0 sm:bg-transparent sm:my-3 sm:py-2">
+        <a class="font-extrabold text-lg leading-5 pl-2 my-3 no-underline text-black sm:my-3 sm:mb-2 sm:text-2xl" href="/">Astro + Sanity</a>
       </header>
-      <main>
+      <main class="mt-[45px] sm:mt-0">
         <slot />
       </main>
-      <footer class="footer">
-        <p class="footer__text">
+      <footer class="flex justify-end px-3 sm:my-3">
+        <p class="text-sm leading-5 flex items-center gap-0.5">
           Made with <svg
             data-sanity-icon="heart-filled"
             width="1em"
@@ -80,143 +81,3 @@ const visualEditingEnabled =
     </div>
   </body>
 </html>
-
-<style>
-  .container {
-    margin: 0 auto;
-  }
-
-  main {
-    margin-top: 45px;
-  }
-
-  .header {
-    display: flex;
-    padding: 0 var(--space-1);
-    border-bottom: 1px solid #ced2d9;
-
-    z-index: 10;
-    background: var(--white);
-    position: fixed;
-    left: 0;
-    right: 0;
-    top: 0;
-
-    & .header__title {
-      font-weight: 800;
-      font-size: var(--font-size-3);
-      line-height: var(--line-height-1);
-      padding-left: var(--space-2);
-      margin: var(--space-3) 0;
-      text-decoration: none;
-      color: var(--black);
-    }
-  }
-
-  .footer {
-    display: flex;
-    justify-content: flex-end;
-    padding: 0 var(--space-3);
-
-    & .footer__text {
-      font-size: var(--font-size-1);
-      line-height: var(--line-height-1);
-      display: flex;
-      align-items: center;
-      gap: 2px;
-    }
-  }
-
-  @media (min-width: 575px) {
-    .container {
-      max-width: var(--max-width-1);
-      padding: 0 var(--space-4);
-    }
-
-    main {
-      margin-top: unset;
-    }
-
-    .header {
-      position: unset;
-      border-bottom: none;
-      margin: var(--space-3) 0;
-      padding: var(--space-2) 0;
-      background: unset;
-
-      & .header__title {
-        margin: var(--space-3) 0 var(--space-2);
-        font-size: var(--font-size-5);
-      }
-    }
-
-    .footer {
-      margin: var(--space-3) 0;
-    }
-  }
-</style>
-
-<style is:global>
-  :root {
-    --space-0: 0;
-    --space-1: 4px;
-    --space-2: 8px;
-    --space-3: 12px;
-    --space-4: 20px;
-    --space-5: 32px;
-    --space-6: 52px;
-    --space-7: 84px;
-    --space-8: 136px;
-    --space-9: 220px;
-
-    --font-family-sans: Inter;
-    --font-family-serif: PT Serif;
-    --font-family-mono: IMB Plex Mono;
-
-    --font-size-0: 12px;
-    --font-size-1: 14px;
-    --font-size-2: 16px;
-    --font-size-3: 18px;
-    --font-size-4: 20px;
-    --font-size-5: 24px;
-    --font-size-6: 30px;
-    --font-size-7: 36px;
-    --font-size-8: 48px;
-    --font-size-9: 60px;
-    --font-size-10: 72px;
-
-    --line-height-0: 16px;
-    --line-height-1: 20px;
-    --line-height-2: 24px;
-    --line-height-3: 28px;
-    --line-height-4: 28px;
-    --line-height-5: 32px;
-    --line-height-6: 36px;
-    --line-height-7: 40px;
-    --line-height-8: 48px;
-    --line-height-9: 60px;
-    --line-height-10: 72px;
-    --line-height-11: 96px;
-    --line-height-12: 128px;
-
-    --white: #fff;
-    --black: #101112;
-    --gray-200: #ced2d9;
-    --gray-600: #6e7683;
-    --blue-600: #1e61cd;
-    --magenta-100: #f9d7eb;
-
-    --max-width-0: 320px;
-    --max-width-1: 768px;
-  }
-
-  html {
-    background-color: var(--white);
-    font-family: var(--font-family-sans), var(--font-family-serif), sans-serif;
-    text-size-adjust: 100%;
-  }
-
-  body {
-    margin: 0;
-  }
-</style>

--- a/frontend/src/pages/404.astro
+++ b/frontend/src/pages/404.astro
@@ -3,62 +3,12 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="Page not found — Astro + Sanity">
-  <div class="not-found">
-    <p class="not-found__code">404</p>
-    <h1 class="not-found__title">Page not found</h1>
-    <p class="not-found__message">
+  <div class="flex flex-col items-start px-3 pt-13 gap-3">
+    <p class="font-mono text-sm font-medium text-gray-600 m-0 tracking-widest">404</p>
+    <h1 class="font-sans text-5xl font-extrabold leading-12 -tracking-[0.025em] m-0 text-black">Page not found</h1>
+    <p class="font-serif text-xl leading-7 text-gray-600 m-0">
       The page you're looking for doesn't exist or has been moved.
     </p>
-    <a class="not-found__link" href="/">← Back to home</a>
+    <a class="font-sans text-base font-medium text-blue-600 no-underline mt-2 hover:underline" href="/">← Back to home</a>
   </div>
 </Layout>
-
-<style>
-  .not-found {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    padding: var(--space-6) var(--space-3);
-    gap: var(--space-3);
-
-    & .not-found__code {
-      font-family: var(--font-family-mono);
-      font-size: var(--font-size-1);
-      font-weight: 500;
-      color: var(--gray-600);
-      margin: 0;
-      letter-spacing: 0.1em;
-    }
-
-    & .not-found__title {
-      font-family: var(--font-family-sans);
-      font-size: var(--font-size-8);
-      font-weight: 800;
-      line-height: var(--line-height-8);
-      letter-spacing: -0.025em;
-      margin: 0;
-      color: var(--black);
-    }
-
-    & .not-found__message {
-      font-family: var(--font-family-serif);
-      font-size: var(--font-size-4);
-      line-height: var(--line-height-4);
-      color: var(--gray-600);
-      margin: 0;
-    }
-
-    & .not-found__link {
-      font-family: var(--font-family-sans);
-      font-size: var(--font-size-2);
-      font-weight: 500;
-      color: var(--blue-600);
-      text-decoration: none;
-      margin-top: var(--space-2);
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-  }
-</style>

--- a/frontend/src/pages/post/[slug].astro
+++ b/frontend/src/pages/post/[slug].astro
@@ -41,11 +41,11 @@ const ogImage = ogImageSource
   description={seoDescription}
   image={ogImage}
 >
-  <section class="post">
+  <section class="w-full my-1 mb-5">
     {
       post.mainImage ? (
         <img
-          class="post__cover"
+          class="w-full h-50 object-cover md:w-187.5 md:h-95"
           src={urlFor(post.mainImage).width(750).auto("format").quality(85).url()}
           srcset={buildSrcSet(post.mainImage, [375, 750, 1200], 85)}
           sizes="(max-width: 800px) 100vw, 750px"
@@ -57,119 +57,18 @@ const ogImage = ogImageSource
           data-sanity={dataAttr?.scope("mainImage").toString()}
         />
       ) : (
-        <div class="post__cover--none" />
+        <div class="w-full h-50 bg-black md:w-187.5 md:h-95" />
       )
     }
-    <div class="post__container">
-      <h1 class="post__title">{post.title}</h1>
-      <p class="post__excerpt" data-sanity={dataAttr?.scope("excerpt").toString()}>{post.excerpt}</p>
-      <p class="post__date">
+    <div class="px-3">
+      <h1 class="font-sans font-extrabold text-4xl leading-9 my-5 md:text-7xl md:leading-18 md:mt-13 md:mb-0 md:-tracking-[0.025em]">{post.title}</h1>
+      <p class="font-serif font-normal text-2xl leading-7 mt-0 md:leading-8 md:mt-3 md:mb-3" data-sanity={dataAttr?.scope("excerpt").toString()}>{post.excerpt}</p>
+      <p class="font-sans font-semibold text-sm leading-5 mt-5 md:text-lg md:leading-6 md:mt-0">
         {formatDate(post._createdAt)}
       </p>
-      <div class="post__content" data-sanity={dataAttr?.scope("body").toString()}>
+      <div class="prose prose-lg prose-serif mt-13 md:mt-21 max-w-none prose-blockquote:border-l-[5px] prose-blockquote:border-black prose-blockquote:pl-3 prose-blockquote:ml-5 prose-a:text-blue-600 prose-a:no-underline" data-sanity={dataAttr?.scope("body").toString()}>
         <PortableText value={post.body} />
       </div>
     </div>
   </section>
 </Layout>
-
-<style>
-  .post {
-    width: 100%;
-    margin: var(--space-1) 0 var(--space-4);
-
-    & .post__cover,
-    & .post__cover--none {
-      width: 100%;
-      height: 200px;
-      object-fit: cover;
-    }
-
-    & .post__cover--none {
-      background: var(--black);
-    }
-
-    & .post__container {
-      padding: 0 var(--space-3);
-    }
-
-    & .post__content {
-      font-family: var(--font-family-serif);
-      font-weight: 400;
-      font-size: var(--font-size-4);
-      line-height: var(--line-height-5);
-      letter-spacing: -0.02em;
-      margin-top: var(--space-6);
-
-      /* Targeting tags in PortableText */
-      & blockquote {
-        border-left: 5px solid var(--black);
-        padding-left: var(--space-3);
-        margin-left: var(--space-4);
-      }
-
-      & a {
-        color: var(--blue-600);
-        text-decoration: none;
-      }
-    }
-
-    & .post__title {
-      font-family: var(--font-family-sans);
-      font-size: var(--font-size-7);
-      line-height: var(--line-height-6);
-      margin: var(--space-4) 0;
-      font-weight: 800;
-    }
-
-    & .post__excerpt {
-      font-family: var(--font-family-serif);
-      font-size: var(--font-size-5);
-      line-height: var(--line-height-4);
-      margin-top: 0;
-      font-weight: 400;
-    }
-
-    & .post__date {
-      font-family: var(--font-family-sans);
-      font-weight: 600;
-      font-size: var(--font-size-1);
-      line-height: var(--line-height-1);
-      margin-top: var(--space-4);
-    }
-  }
-
-  @media (min-width: 800px) {
-    .post {
-      & .post__cover,
-      & .post__cover--none {
-        width: 750px;
-        height: 380px;
-      }
-
-      & .post__title {
-        font-size: var(--font-size-10);
-        line-height: var(--line-height-10);
-        margin: var(--space-6) 0 0;
-        letter-spacing: -0.025em;
-      }
-
-      & .post__excerpt {
-        font-size: var(--font-size-5);
-        line-height: var(--line-height-5);
-        margin-top: var(--space-3);
-        margin-bottom: var(--space-3);
-      }
-
-      & .post__date {
-        font-size: var(--font-size-3);
-        line-height: var(--line-height-2);
-        margin-top: var(--space-0);
-      }
-
-      & .post__content {
-        margin-top: var(--space-7);
-      }
-    }
-  }
-</style>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,25 @@
+@import "tailwindcss";
+@plugin "@tailwindcss/typography";
+
+@theme {
+  --font-sans: "Inter", sans-serif;
+  --font-serif: "PT Serif", serif;
+  --font-mono: "IBM Plex Mono", monospace;
+
+  --color-white: #fff;
+  --color-black: #101112;
+  --color-gray-200: #ced2d9;
+  --color-gray-600: #6e7683;
+  --color-blue-600: #1e61cd;
+  --color-magenta-100: #f9d7eb;
+}
+
+html {
+  background-color: var(--color-white);
+  font-family: var(--font-sans);
+  text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@sanity/astro": "^3.3.1",
         "@sanity/client": "^7.21.0",
         "@sanity/image-url": "^2.1.1",
+        "@tailwindcss/vite": "^4.2.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "astro": "^6.1.6",
@@ -36,11 +37,13 @@
         "react-dom": "^19.2.5",
         "react-is": "^19.2.5",
         "sanity": "^5.20.0",
-        "styled-components": "^6.4.0"
+        "styled-components": "^6.4.0",
+        "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
         "@portabletext/types": "^4.0.2",
         "@sanity/types": "^5.20.0",
+        "@tailwindcss/typography": "^0.5.19",
         "prettier": "^3.8.2",
         "prettier-plugin-astro": "^0.14.1",
         "typescript": "^5.9.3"
@@ -7730,6 +7733,288 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@tanstack/react-table": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
@@ -10273,6 +10558,19 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csso": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
@@ -10875,6 +11173,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -14252,6 +14563,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -16687,6 +17259,20 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -18837,6 +19423,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/tar": {
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
@@ -19081,13 +19686,6 @@
       "resolved": "https://registry.npmjs.org/ts-brand/-/ts-brand-0.2.0.tgz",
       "integrity": "sha512-H5uo7OqMvd91D2EefFmltBP9oeNInNzWLAZUSt6coGDn8b814Eis6SnEtzyXORr9ccEb38PfzyiRVDacdkycSQ==",
       "license": "MIT"
-    },
-    "node_modules/ts-toolbelt": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
-      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
-      "license": "Apache-2.0",
-      "peer": true
     },
     "node_modules/ts-type": {
       "version": "3.0.13",


### PR DESCRIPTION
## Summary
- Installs Tailwind CSS v4 (`tailwindcss`, `@tailwindcss/vite`) and `@tailwindcss/typography`
- Configures custom theme in `src/styles/global.css` preserving existing design tokens (fonts, colors)
- Replaces all scoped `<style>` blocks across Layout, Card, Welcome, post detail, and 404 pages with Tailwind utility classes
- Uses `prose` from `@tailwindcss/typography` to style PortableText rendered content on post pages

## Test plan
- [ ] Run `npm run dev` in `frontend/` and verify homepage renders correctly
- [ ] Verify post detail pages render with proper typography (headings, blockquotes, links)
- [ ] Check responsive layout at mobile and desktop breakpoints
- [ ] Verify 404 page styling
- [ ] Run `npm run build` to confirm production build succeeds