### PR TITLE
Add code block support with @sanity/code-input and syntax highlighting

### DIFF
--- a/frontend/src/components/CodeBlock.astro
+++ b/frontend/src/components/CodeBlock.astro
@@ -1,0 +1,61 @@
+---
+import { createHighlighter, type BundledLanguage, bundledLanguages } from "shiki";
+
+const { node } = Astro.props;
+const { code, language, filename } = node;
+
+// Map language aliases and fall back to "text" for unsupported languages
+const langAliases: Record<string, string> = {
+  groq: "javascript",
+  astro: "tsx",
+};
+
+const resolvedLang = langAliases[language] ?? language ?? "text";
+const lang = resolvedLang in bundledLanguages ? resolvedLang : "text";
+
+const highlighter = await createHighlighter({
+  themes: ["github-dark-dimmed"],
+  langs: [lang as BundledLanguage],
+});
+
+const html = highlighter.codeToHtml(code, {
+  lang,
+  theme: "github-dark-dimmed",
+});
+---
+
+<div class="code-block">
+  {filename && <div class="code-block__filename">{filename}</div>}
+  <Fragment set:html={html} />
+</div>
+
+<style is:global>
+  .code-block {
+    margin: var(--space-4) 0;
+    border-radius: 6px;
+    overflow: hidden;
+    font-size: var(--font-size-1);
+    line-height: 1.7;
+  }
+
+  .code-block__filename {
+    padding: 8px 16px;
+    background: #1c2028;
+    color: #768390;
+    font-family: var(--font-family-mono), monospace;
+    font-size: var(--font-size-0);
+    border-bottom: 1px solid #373e47;
+  }
+
+  .code-block pre.shiki {
+    margin: 0;
+    padding: 16px;
+    overflow-x: auto;
+    font-family: var(--font-family-mono), monospace;
+    tab-size: 2;
+  }
+
+  .code-block pre.shiki code {
+    font-family: inherit;
+  }
+</style>

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -171,7 +171,7 @@ const visualEditingEnabled =
 
     --font-family-sans: Inter;
     --font-family-serif: PT Serif;
-    --font-family-mono: IMB Plex Mono;
+    --font-family-mono: IBM Plex Mono;
 
     --font-size-0: 12px;
     --font-size-1: 14px;

--- a/frontend/src/pages/post/[slug].astro
+++ b/frontend/src/pages/post/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { PortableText } from "astro-portabletext";
 import { createDataAttribute } from "@sanity/visual-editing-csm";
+import CodeBlock from "../../components/CodeBlock.astro";
 import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils";
 import { urlFor, buildSrcSet } from "../../utils/image";
@@ -67,7 +68,7 @@ const ogImage = ogImageSource
         {formatDate(post._createdAt)}
       </p>
       <div class="post__content" data-sanity={dataAttr?.scope("body").toString()}>
-        <PortableText value={post.body} />
+        <PortableText value={post.body} components={{ type: { code: CodeBlock } }} />
       </div>
     </div>
   </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,6 +2359,46 @@
         "@lezer/common": "^1.1.0"
       }
     },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.2.tgz",
+      "integrity": "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/lang-javascript": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
@@ -2374,6 +2414,58 @@
         "@lezer/javascript": "^1.0.0"
       }
     },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-php": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+      "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/language": {
       "version": "6.12.3",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
@@ -2386,6 +2478,15 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz",
+      "integrity": "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
       }
     },
     "node_modules/@codemirror/lint": {
@@ -4312,6 +4413,17 @@
       "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
       "license": "MIT"
     },
+    "node_modules/@lezer/css": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
     "node_modules/@lezer/highlight": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
@@ -4319,6 +4431,28 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/javascript": {
@@ -4332,6 +4466,17 @@
         "@lezer/lr": "^1.3.0"
       }
     },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@lezer/lr": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
@@ -4339,6 +4484,27 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/php": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
+      "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.1.0"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -6277,6 +6443,39 @@
         "node": ">=20"
       }
     },
+    "node_modules/@sanity/code-input": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@sanity/code-input/-/code-input-7.1.0.tgz",
+      "integrity": "sha512-fVo7qgK6LtWMvxJkBMEhXM2DWtmA06f7HlAswlpImmMZevmg7DoYSPMT/dMZyJuzoHzIK3Bb5ukN+9Ua+bLVDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.4.11",
+        "@codemirror/lang-java": "^6.0.2",
+        "@codemirror/lang-javascript": "^6.2.5",
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/lang-php": "^6.0.2",
+        "@codemirror/lang-sql": "^6.10.0",
+        "@codemirror/language": "^6.12.2",
+        "@codemirror/legacy-modes": "^6.5.2",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.40.0",
+        "@lezer/highlight": "^1.2.3",
+        "@sanity/icons": "^3.7.4",
+        "@sanity/lezer-groq": "^1.0.3",
+        "@sanity/ui": "^3.1.14",
+        "@uiw/codemirror-themes": "^4.25.8",
+        "@uiw/react-codemirror": "^4.25.8"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "react": "^19.2",
+        "sanity": "^5",
+        "styled-components": "^6.1"
+      }
+    },
     "node_modules/@sanity/codegen": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-6.0.2.tgz",
@@ -6598,6 +6797,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.2"
+      }
+    },
+    "node_modules/@sanity/lezer-groq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@sanity/lezer-groq/-/lezer-groq-1.0.3.tgz",
+      "integrity": "sha512-Vw27wIH+eoqcefadRTmeV2f6hnpocwUk3f2HhkQ15beCy8YkzEeV8Gp+gG/nJP8Y4nYzjbK1XOSP88ju2T8YEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@sanity/logos": {
@@ -8296,6 +8507,25 @@
         "@codemirror/language": ">=6.0.0",
         "@codemirror/lint": ">=6.0.0",
         "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/codemirror-themes": {
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.25.9.tgz",
+      "integrity": "sha512-DAHKb/L9ELwjY4nCf/MP/mIllHOn4GQe7RR4x8AMJuNeh9nGRRoo1uPxrxMmUL/bKqe6kDmDbIZ2AlhlqyIJuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/language": ">=6.0.0",
         "@codemirror/state": ">=6.0.0",
         "@codemirror/view": ">=6.0.0"
       }
@@ -21006,6 +21236,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
+        "@sanity/code-input": "^7.1.0",
         "@sanity/vision": "^5.20.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",

--- a/studio/package.json
+++ b/studio/package.json
@@ -15,6 +15,7 @@
     "sanity"
   ],
   "dependencies": {
+    "@sanity/code-input": "^7.1.0",
     "@sanity/vision": "^5.20.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -1,6 +1,7 @@
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
+import {codeInput} from '@sanity/code-input'
 import {defineDocuments, defineLocations, presentationTool} from 'sanity/presentation'
 import {schemaTypes} from './src/schemaTypes'
 
@@ -44,6 +45,7 @@ export default defineConfig({
       },
     }),
     visionTool(),
+    codeInput(),
   ],
   schema: {types: schemaTypes},
 })

--- a/studio/src/schemaTypes/objects/blockContent.tsx
+++ b/studio/src/schemaTypes/objects/blockContent.tsx
@@ -56,5 +56,8 @@ export default defineType({
         ],
       },
     }),
+    defineArrayMember({
+      type: 'code',
+    }),
   ],
 })


### PR DESCRIPTION
## Summary
- Adds the `@sanity/code-input` plugin to the Studio so editors can insert code blocks in post body content
- Creates a `CodeBlock.astro` frontend component that uses Shiki (bundled with Astro) for syntax highlighting with the `github-dark-dimmed` theme
- Wires the component into PortableText rendering via the `components` prop
- Maps unsupported Shiki languages (`groq` → `javascript`, `astro` → `tsx`) with a fallback to plain `text`
- Fixes a typo in the mono font CSS variable (`IMB` → `IBM Plex Mono`)

## Changed files
- `studio/package.json` — add `@sanity/code-input` dependency
- `studio/sanity.config.ts` — register `codeInput()` plugin
- `studio/src/schemaTypes/objects/blockContent.tsx` — add `code` array member
- `frontend/src/components/CodeBlock.astro` — new component for rendering code blocks
- `frontend/src/pages/post/[slug].astro` — pass `CodeBlock` to PortableText
- `frontend/src/layouts/Layout.astro` — fix font variable typo

## Test plan
- [ ] Open a post in the Studio and verify the code input block is available in the body field
- [ ] Add a code block with a supported language (e.g., TypeScript) and verify syntax highlighting on the frontend
- [ ] Add a code block with an unsupported language (e.g., GROQ) and verify it falls back gracefully
- [ ] Verify the filename header renders when a filename is provided
- [ ] Verify IBM Plex Mono font renders correctly in code blocks