### PR TITLE
add an Assure Typing Interval upgrade

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,3 +8,14 @@ SANITY_API_READ_TOKEN=""
 PUBLIC_SANITY_STUDIO_URL=""
 # Optional - Visual Editing - set to "true" to enable overlays in Presentation tool
 PUBLIC_SANITY_VISUAL_EDITING_ENABLED="false"
+
+# here we control a fix on Astro's visual editing as implemented
+# by a loosely coupled loop, which will miss characters typed
+# soon after a pause, typical in choosing a sentence ending.
+
+# 1200 ms is the default delay if this var isn't set. You can
+# tune the extra refresh which catches those chars typed during
+# the blind time where the browser is refreshing. If desired,
+# setting a negative value will turn off the feature.
+
+PUBLIC_SANITY_ASSURE_TYPING_INTERVAL=1200

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -13,8 +13,69 @@ const canonicalURL = Astro.url;
 
 // Enable visual editing overlays when the env variable is set to "true"
 const visualEditingEnabled =
-  import.meta.env.PUBLIC_SANITY_VISUAL_EDITING_ENABLED === "true";
+  import.meta.env.PUBLIC_SANITY_VISUAL_EDITING_ENABLED === "true"
+const assureTypingInterval:Number
+  = Number(import.meta.env.PUBLIC_SANITY_ASSURE_TYPING_INTERVAL
+  || 1200)
+console.log('assure typing interval: ' + assureTypingInterval);
 ---
+<!--
+  NOTE: 'define:vars' implicitly enforces 'is:inline' behavior.
+  Do not combine them, as it can cause compilation syntax conflicts.
+  We must define the var to have it passed from js section
+-->
+<script define:vars={{ assureTypingInterval }}>
+  (function() {
+
+    // Only operate within the Studio's context,
+    // and if not defeated by negative value flag
+    if (window.self === window.top) return
+    if (assureTypingInterval <= 0) {
+      console.log ('PUBLIC_SANITY_ASSURE_TYPING_INTERVAL set negative, thus defeated.')
+      return;
+    }
+
+    const FLAG = 'sanity_sync_needed';
+    let packetCount = 0;
+
+    // 1. OBSERVE: Monitor the Studio's snapshot stream
+    window.addEventListener('message', (e) => {
+
+      // Catching the v5.6+ Snapshot volume
+      if (e.data?.type === 'presentation/preview-snapshots') {
+        sessionStorage.setItem(FLAG, 'true');
+        packetCount++;
+        // Verbose level: verifies packet flow without clutter
+        console.debug(`[Sanity Observer] Packet #${packetCount} buffered.`);
+      }
+    });
+
+    // 2. RECONCILE: Check for missed updates on page arrival
+    window.addEventListener('load', () => {
+      const needsSync = sessionStorage.getItem(FLAG) === 'true';
+
+      if (needsSync) {
+        // Clear flag immediately to ensure idempotency
+        sessionStorage.removeItem(FLAG);
+
+        // Blue info: Formal acknowledgement of the blind window
+        console.info('%c[Sanity Sync] Blind window detected. Tail-end updates identified.', 'color: #0088ff; font-weight: bold;');
+
+        // The 'Humanistic' pause for recursive queries to settle
+        // n.b. we have to evaluate template-style, _and_ outside
+        // the function call. These are Astro rules....
+        setTimeout(() => {
+          // Yellow warning: The corrective sweep action
+          console.warn('%c[Sanity Sync] EXECUTING CORRECTIVE SWEEP.', 'color: #856404; font-weight: bold; background-color: #fff3cd; border: 1px solid #ffeeba; padding: 2px 4px;');
+          window.location.reload();
+        }, assureTypingInterval); // must evaluate
+      } else {
+        // Green success: Confirmation of a high-fidelity 'atomic' load
+        console.log('%c[Sanity Sync] Page load stable. All characters accounted for.', 'color: #28a745;');
+      }
+    });
+  })();
+</script>
 
 <!doctype html>
 <html lang="en">

--- a/package-lock.json
+++ b/package-lock.json
@@ -8069,9 +8069,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8087,9 +8084,6 @@
       "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8107,9 +8101,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8125,9 +8116,6 @@
       "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -14929,9 +14917,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14951,9 +14936,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -14975,9 +14957,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14997,9 +14976,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,


### PR DESCRIPTION
add the Assure Typing Interval upgrade, so typing during the browser refresh for visual editing update will be picked up by a secondary refresh (from the Content Lake, as the VE mechanism always uses)

### Description

A script is added in the Layout.astro file, which will add an extra refresh a set time after Visual Editing has called for its content uipdate refresh. This avoids the usual missing characters that occur when as in normal content typing, a little is added after a short pause. Which is a normal thing for a content editor to do, pausing to consider an ending.

The script will automatically be is:inline, due to the define:vars tag, and it is recommended against to also have is:inline, as this will confuse Astro. Either method gives the desired result that the script will be handled up-front, and on its own.

There are no known issues, as the extra refresh is as invisible as Visual Editing refreshes themselves, both just altering local details of the text displayed to match the Content Lake, set by typing. 

This is all normal operation of the Astro implementation of Visual Editing, only tightening up the very loose coupling. Without it, characters will be missed in many situations, and not appear until something else is typed. Which at the end or a content entry, will b every awkward even if you know the trick, as you'd have to type a little more, then erase it, within the timing to avoid another screen to Content Lake mismatch. 

It has to be done here, as there's no way to determine the delay conditions from the studio end.

### What to review

A diff on src/layouts/Layout.astro will show the added code, while .env.example has the notes if you want to add an environmental to alter the timeout for unusual circumstances, perhaps a very long page.

In this code there are a set of console.logs which allow seeing operation on the browser console, not at a rate different from the notes occurring there due to various message losses the Visual Editing refresh always causes.

### Testing

It's a bit of a trick to test unless you first test without the fix, which you can do by setting the environmental to a negative number as its doc suggets. 

Then you would need to learn for your execution (dev mode is fine, just slower) what interval of stopping short typing, pause, then tyiping a few characters more needs to start dropping the last characters. At this point you ocan verify total operation by typing a little more after you notice the missed characters. In normal operation, they'll show along with the extra once it refreshes. Unless you lose a little of the extra, which is the same basis problem showing again.

Now, by removing the environmental, or setting it as in the example, then restarting your dev operation, you can try the typing test again, remembering the pause which caused the lost characters. Now they'll appear automatically a short time after the original broken typing showed, for a complete rendering of whaty you keyed. That's the reliability we're after.
